### PR TITLE
add prefix deepdanbooru_tag2folder_ to element id

### DIFF
--- a/scripts/deepdanbooru_tag2folder.py
+++ b/scripts/deepdanbooru_tag2folder.py
@@ -67,6 +67,11 @@ class DeepDanbooruWrapper:
 
         return probability_dict
 
+
+def element_id_prefix(element_id):
+    return f'deepdanboru_tag2folder_{element_id}'
+
+
 class DeepDanbooruTag2FolderScript():
 
     def __init__(self):
@@ -87,16 +92,16 @@ class DeepDanbooruTag2FolderScript():
             with gr.Row():
 
                 with gr.Column(scale=1, elem_classes="source-image-col"):
-                    self.source_folder = gr.Textbox(value="", label="Source Folder", elem_id="source_folder")
-                    self.target_folder = gr.Textbox(value="", label="Target Folder", elem_id="target_folder")
-                    self.auto_type = gr.Dropdown(["None", "Character", "Anime"], value="None", label="Automatic Type", elem_id="auto_type")
-                    self.threshold = gr.Number(value=0.5, label="Threshold", elem_id="threshold", minimum=0, maximum=1)
+                    self.source_folder = gr.Textbox(value="", label="Source Folder", elem_id=element_id_prefix("source_folder"))
+                    self.target_folder = gr.Textbox(value="", label="Target Folder", elem_id=element_id_prefix("target_folder"))
+                    self.auto_type = gr.Dropdown(["None", "Character", "Anime"], value="None", label="Automatic Type", elem_id=element_id_prefix("auto_type"))
+                    self.threshold = gr.Number(value=0.5, label="Threshold", elem_id=element_id_prefix("threshold"), minimum=0, maximum=1)
 
                 with gr.Column(scale=1, elem_classes="other elements"):
-                    self.rules = gr.Textbox(value=json.dumps(sample, indent=True), lines=10, label="Rules", elem_id="rules_json")
+                    self.rules = gr.Textbox(value=json.dumps(sample, indent=True), lines=10, label="Rules", elem_id=element_id_prefix("rules_json"))
 
             with gr.Row():
-                self.process_btn = gr.Button(value="Process", elem_id="process_btn")
+                self.process_btn = gr.Button(value="Process", elem_id=element_id_prefix("process_btn"))
 
             self.process_btn.click(
                 self.ui_click,


### PR DESCRIPTION
your IDs are too generic
use unique IDs or don't specify otherwise it might cause issues

they're also other changes that you might want to consider if you wish you can pull this branch
https://github.com/w-e-w/sd-webui-deepdanbooru-tag2folder/tree/other-changes

---

Note values will be save to `ui-config.json` unless the `do_not_save_to_config` attribute is set to `True`
users can change the default values using the `Setting > Defaults` feature

placeholders won't be saved to ui-config.json 
so in my opinion using placeholders for examples are better 



